### PR TITLE
Add /makeCall endpoint to support client-to-number/client Dial

### DIFF
--- a/server.py
+++ b/server.py
@@ -25,6 +25,9 @@ IDENTITY = 'alice'
 
 app = Flask(__name__)
 
+"""
+Creates an access token with VoiceGrant using your Twilio credentials.
+"""
 @app.route('/accessToken')
 def token():
   account_sid = os.environ.get("ACCOUNT_SID", ACCOUNT_SID)
@@ -43,18 +46,27 @@ def token():
 
   return str(token)
 
+"""
+Creates an endpoint that plays back a greeting when the outbound call is connected.
+"""
 @app.route('/outgoing', methods=['GET', 'POST'])
 def outgoing():
   resp = VoiceResponse()
   resp.say("Congratulations! You have made your first oubound call! Good bye.")
   return str(resp)
 
+"""
+Creates an endpoint that plays back a greeting.
+"""
 @app.route('/incoming', methods=['GET', 'POST'])
 def incoming():
   resp = VoiceResponse()
   resp.say("Congratulations! You have received your first inbound call! Good bye.")
   return str(resp)
 
+"""
+Makes a call to the specified client using the Twilio REST API.
+"""
 @app.route('/placeCall', methods=['GET', 'POST'])
 def placeCall():
   account_sid = os.environ.get("ACCOUNT_SID", ACCOUNT_SID)
@@ -65,9 +77,16 @@ def placeCall():
   call = client.calls.create(url=request.url_root + 'incoming', to='client:' + IDENTITY, from_='client:' + CALLER_ID)
   return str(call.sid)
 
+"""
+Creates an endpoint that can be used in your TwiML App as the Voice Request Url.
+
+In order to make an outgoing call using Twilio Voice SDK, you need to provide a
+TwiML App SID in the Access Token. You can run your server, make it publicly
+accessible and use `/makeCall` endpoint as the Voice Request Url in your TwiML App.
+"""
 @app.route('/makeCall', methods=['GET', 'POST'])
 def makeCall():
-  response = twilio.twiml.Response()
+  response = VoiceResponse()
   to = request.form.get('to')
   if not to or len(to) == 0:
     response.say("Congratulations! You have just made your first call! Good bye.")

--- a/server.py
+++ b/server.py
@@ -44,6 +44,7 @@ def outgoing():
 @app.route('/placeCall', methods=['GET', 'POST'])
 def placeCall():
     response = twilio.twiml.Response()
+    # For simplicity, the following code assumes that identity name starts only with letters and not with numbers.
     to = request.form.get('server_param_to', IDENTITY)
     if to[0] in "+1234567890":
         response.dial(callerId=CALLER_NUMBER).number(to)

--- a/server.py
+++ b/server.py
@@ -47,15 +47,6 @@ def token():
   return str(token)
 
 """
-Creates an endpoint that plays back a greeting when the outbound call is connected.
-"""
-@app.route('/outgoing', methods=['GET', 'POST'])
-def outgoing():
-  resp = VoiceResponse()
-  resp.say("Congratulations! You have made your first oubound call! Good bye.")
-  return str(resp)
-
-"""
 Creates an endpoint that plays back a greeting.
 """
 @app.route('/incoming', methods=['GET', 'POST'])

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ APP_SID = 'AP***'
 """
 Use a valid Twilio number by adding to your account via https://www.twilio.com/console/phone-numbers/verified
 """
-CALLER_NUMBER = '0123456789'
+CALLER_NUMBER = '1234567890'
 
 """
 The caller id used when a client is dialed.

--- a/server.py
+++ b/server.py
@@ -48,8 +48,24 @@ def outgoing():
   resp.say("Congratulations! You have just made your first oubound call! Good bye.")
   return str(resp)
 
+@app.route('/incoming', methods=['GET', 'POST'])
+def incoming():
+  resp = twilio.twiml.Response()
+  resp.say("Congratulations! You have received your first inbound call! Good bye.")
+  return str(resp)
+
 @app.route('/placeCall', methods=['GET', 'POST'])
 def placeCall():
+  account_sid = os.environ.get("ACCOUNT_SID", ACCOUNT_SID)
+  api_key = os.environ.get("API_KEY", API_KEY)
+  api_key_secret = os.environ.get("API_KEY_SECRET", API_KEY_SECRET)
+
+  client = Client(api_key, api_key_secret, account_sid)
+  call = client.calls.create(url=request.url_root + 'incoming', to='client:' + IDENTITY, from_='client:' + CALLER_ID)
+  return str(call.sid)
+
+@app.route('/makeCall', methods=['GET', 'POST'])
+def makeCall():
   response = twilio.twiml.Response()
   to = request.form.get('to')
   if not to or len(to) == 0:

--- a/server.py
+++ b/server.py
@@ -19,7 +19,7 @@ CALLER_NUMBER = '0123456789'
 The caller id used when a client is dialed.
 """
 CALLER_ID = 'client:quick_start'
-IDENTITY = 'voice_test'
+IDENTITY = 'alice'
 
 
 app = Flask(__name__)

--- a/server.py
+++ b/server.py
@@ -10,10 +10,17 @@ API_KEY_SECRET = '***'
 PUSH_CREDENTIAL_SID = 'CR***'
 APP_SID = 'AP***'
 
-# Replace the value of `CALLER_NUMBER` with a valid Twilio number under the account.
-CALLER_NUMBER = '14151234567'
+"""
+Use a valid Twilio number by adding to your account via https://www.twilio.com/console/phone-numbers/verified
+"""
+CALLER_NUMBER = '0123456789'
+
+"""
+The caller id used when a client is dialed.
+"""
+CALLER_ID = 'client:quick_start'
 IDENTITY = 'voice_test'
-CALLER_ID = 'quick_start'
+
 
 app = Flask(__name__)
 
@@ -38,19 +45,20 @@ def token():
 @app.route('/outgoing', methods=['GET', 'POST'])
 def outgoing():
   resp = twilio.twiml.Response()
-  resp.say("Congratulations! You have made your first oubound call! Good bye.")
+  resp.say("Congratulations! You have just made your first oubound call! Good bye.")
   return str(resp)
 
 @app.route('/placeCall', methods=['GET', 'POST'])
 def placeCall():
-    response = twilio.twiml.Response()
-    # For simplicity, the following code assumes that identity name starts only with letters and not with numbers.
-    to = request.form.get('server_param_to', IDENTITY)
-    if to[0] in "+1234567890":
-        response.dial(callerId=CALLER_NUMBER).number(to)
-    else:
-        response.dial(callerId='client:'+CALLER_ID).client(to)
-    return str(response)
+  response = twilio.twiml.Response()
+  to = request.form.get('to')
+  if not to or len(to) == 0:
+    response.say("Congratulations! You have just made your first call! Good bye.")
+  elif to[0] in "+1234567890":
+    response.dial(callerId=CALLER_NUMBER).number(to)
+  else:
+    response.dial(callerId=CALLER_ID).client(to)
+  return str(response)
 
 @app.route('/', methods=['GET', 'POST'])
 def welcome():

--- a/server.py
+++ b/server.py
@@ -10,6 +10,7 @@ API_KEY_SECRET = '***'
 PUSH_CREDENTIAL_SID = 'CR***'
 APP_SID = 'AP***'
 
+# Replace the value of `CALLER_NUMBER` with a valid Twilio number under the account.
 CALLER_NUMBER = '14151234567'
 IDENTITY = 'voice_test'
 CALLER_ID = 'quick_start'

--- a/server.py
+++ b/server.py
@@ -10,6 +10,7 @@ API_KEY_SECRET = '***'
 PUSH_CREDENTIAL_SID = 'CR***'
 APP_SID = 'AP***'
 
+CALLER_NUMBER = '14151234567'
 IDENTITY = 'voice_test'
 CALLER_ID = 'quick_start'
 
@@ -39,21 +40,15 @@ def outgoing():
   resp.say("Congratulations! You have made your first oubound call! Good bye.")
   return str(resp)
 
-@app.route('/incoming', methods=['GET', 'POST'])
-def incoming():
-  resp = twilio.twiml.Response()
-  resp.say("Congratulations! You have received your first inbound call! Good bye.")
-  return str(resp)
-
 @app.route('/placeCall', methods=['GET', 'POST'])
 def placeCall():
-  account_sid = os.environ.get("ACCOUNT_SID", ACCOUNT_SID)
-  api_key = os.environ.get("API_KEY", API_KEY)
-  api_key_secret = os.environ.get("API_KEY_SECRET", API_KEY_SECRET)
-
-  client = Client(api_key, api_key_secret, account_sid)
-  call = client.calls.create(url=request.url_root + 'incoming', to='client:' + IDENTITY, from_='client:' + CALLER_ID)
-  return str(call.sid)
+    response = twilio.twiml.Response()
+    to = request.form.get('server_param_to', IDENTITY)
+    if to[0] in "+1234567890":
+        response.dial(callerId=CALLER_NUMBER).number(to)
+    else:
+        response.dial(callerId='client:'+CALLER_ID).client(to)
+    return str(response)
 
 @app.route('/', methods=['GET', 'POST'])
 def welcome():

--- a/server.py
+++ b/server.py
@@ -45,7 +45,7 @@ def token():
 @app.route('/outgoing', methods=['GET', 'POST'])
 def outgoing():
   resp = twilio.twiml.Response()
-  resp.say("Congratulations! You have just made your first oubound call! Good bye.")
+  resp.say("Congratulations! You have made your first oubound call! Good bye.")
   return str(resp)
 
 @app.route('/incoming', methods=['GET', 'POST'])


### PR DESCRIPTION
Add a new `/placeCall` endpoint to support different functions based on the HTTP param `to`:
- Play a message using `<Say>` if the `to` value is empty.
- Dial to a PSTN number if the first character of `to` value is one of `{+1234567890}`
- Dial to another client otherwise