### PR TITLE
Fixed VoiceGrant import

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 import os
 from flask import Flask, request
-from twilio.jwt.access_token import AccessToken, VoiceGrant
+from twilio.jwt.access_token import AccessToken
+from twilio.jwt.access_token.grants import VoiceGrant
 from twilio.rest import Client
 import twilio.twiml
 


### PR DESCRIPTION
Without this, starting the server fails with:

```
$ python server.py
Traceback (most recent call last):
  File "server.py", line 3, in <module>
    from twilio.jwt.access_token import AccessToken, VoiceGrant
ImportError: cannot import name VoiceGrant
```

The change seems to have been introduced here:
https://github.com/twilio/twilio-python/commit/5d0c907500c25d5383d8056c9357a5a738692f03